### PR TITLE
Fixing command for os security packages warning

### DIFF
--- a/modules/nagios/templates/checks/check_security_updates
+++ b/modules/nagios/templates/checks/check_security_updates
@@ -9,10 +9,10 @@ apt-get -o Dir::Etc::sourcelist=$list -o Dir::Etc::sourceparts="-" update > /dev
 EXITCODE=${?}
 
 # Depending on the statuscode there might be updates.
-if [ ${EXITCODE} -eq "1" ]; then
+if [ "${EXITCODE}" -eq "1" ]; then
        echo "WARNING: There are updates pending for `hostname`"
        exit 1;
-  elif [ ${EXITCODE} -eq "0" ]; then
+  elif [ "${EXITCODE}" -eq "0" ]; then
        echo "OK: No updates are available for `hostname`";
        exit 0;
   else


### PR DESCRIPTION
Current command still reports updates even if all security updates have been applied. I think the command also includes non-security updates. I think the key is the sourceparts. Verified this script by running it on a variety of machines that had login warnings warning that there are security updates, and running "unattended-upgrade" and verifying that the script no longer reports security updates.
