### PR TITLE
Slay the BEAST

### DIFF
--- a/modules/nginx/templates/admin_tenant_nginx.conf.erb
+++ b/modules/nginx/templates/admin_tenant_nginx.conf.erb
@@ -17,6 +17,7 @@ server {
     ssl_certificate_key  <%= ssl_key_path %>;
 
     # Prevent BEAST attack
+    # @see http://www.kb.cert.org/vuls/id/864643
     ssl_ciphers RC4:HIGH:!aNULL:!MD5;
     ssl_prefer_server_ciphers on;
 

--- a/modules/nginx/templates/user_tenant_nginx.conf.erb
+++ b/modules/nginx/templates/user_tenant_nginx.conf.erb
@@ -28,6 +28,7 @@ server {
     ssl_certificate_key  <%= ssl_key_path %>;
 
     # Prevent BEAST attack
+    # @see http://www.kb.cert.org/vuls/id/864643
     ssl_ciphers RC4:HIGH:!aNULL:!MD5;
     ssl_prefer_server_ciphers on;
 


### PR DESCRIPTION
http://rud.is/b/2012/04/28/slaying-the-beast-in-nginx/

Assigning to @stuartf 

Would be good to apply this in puppet and give it a whirl in qa1. What we're looking for is:
- The Qualsys test identifies that we're no longer vulnerable
- SSL still works as expected in IE, FireFox, Chrome, Safari
- The SSL decryption time hasn't drastically increased. Currently (according to our Circonus pings) our SSL time is roughly 400ms. A comparison before and after would be necessary
