### PR TITLE
Bumped Redis from 2.6.14 to 2.6.16

### DIFF
--- a/environments/performance/hiera/common.json
+++ b/environments/performance/hiera/common.json
@@ -143,7 +143,7 @@
 
     "redis::owner": "redis",
     "redis::group": "redis",
-    "redis::version": "2:2.6.14-1~dotdeb.1",
+    "redis::version": "2:2.6.16-1~dotdeb.1",
 
     "rsyslog::clientOrServer": "client",
 

--- a/environments/production/hiera/common.json
+++ b/environments/production/hiera/common.json
@@ -148,7 +148,7 @@
 
     "redis::owner": "redis",
     "redis::group": "redis",
-    "redis::version": "2:2.6.14-1~dotdeb.1",
+    "redis::version": "2:2.6.16-1~dotdeb.1",
 
     "rsyslog::clientOrServer": "client",
     "rsyslog::server_logdir": "/var/log/rsyslog",

--- a/environments/qa/hiera/common.json
+++ b/environments/qa/hiera/common.json
@@ -127,7 +127,7 @@
 
     "redis::owner": "redis",
     "redis::group": "redis",
-    "redis::version": "2:2.6.14-1~dotdeb.1",
+    "redis::version": "2:2.6.16-1~dotdeb.1",
 
     "hilary::config_activity_enabled": true,
     "hilary::config_previews_enabled": true,

--- a/environments/staging/hiera/common.json
+++ b/environments/staging/hiera/common.json
@@ -145,7 +145,7 @@
 
     "redis::owner": "redis",
     "redis::group": "redis",
-    "redis::version": "2:2.6.14-1~dotdeb.1",
+    "redis::version": "2:2.6.16-1~dotdeb.1",
 
     "rsyslog::clientOrServer": "client",
     "rsyslog::server_logdir": "/var/log/rsyslog",


### PR DESCRIPTION
2.6.14 is no longer available in the dotdeb repository.

It would be good if this would get merged before the bugbash, so it can be deployed on production in the next deploy cycle as well
