### PR TITLE
Increase search version to 0.90.5

### DIFF
--- a/environments/local/hiera/common.json
+++ b/environments/local/hiera/common.json
@@ -64,8 +64,8 @@
     "search_index": "0",
     "search_data_dir": "/var/lib/elasticsearch",
     "search_memory_mb": 512,
-    "search_version": "0.20.6",
-    "search_checksum": "8896b1dde95a09f27a3ec7d027f995ec27cd358f",
+    "search_version": "0.90.5",
+    "search_checksum": "38b21f8b7d1cedd1fffe3ae928d3b06c6241ea1c",
 
     "etherpad_internal_hosts": [ "127.0.0.1" ],
     "etherpad_index": 0,

--- a/environments/performance/hiera/common.json
+++ b/environments/performance/hiera/common.json
@@ -92,8 +92,8 @@
     "search_data_dir": "/var/lib/elasticsearch",
     "search_memory_mb": 3072,
     "search_newsize_mb": 1024,
-    "search_version": "0.20.6",
-    "search_checksum": "8896b1dde95a09f27a3ec7d027f995ec27cd358f",
+    "search_version": "0.90.5",
+    "search_checksum": "38b21f8b7d1cedd1fffe3ae928d3b06c6241ea1c",
 
     "etherpad_internal_hosts": [ "etherpad0", "etherpad1", "etherpad2" ],
     "etherpad_index": "%{nodesuffix}",

--- a/environments/production/hiera/common.json
+++ b/environments/production/hiera/common.json
@@ -98,8 +98,8 @@
     "search_data_dir": "/data/elasticsearch",
     "search_memory_mb": 3072,
     "search_newsize_mb": 1024,
-    "search_version": "0.20.6",
-    "search_checksum": "8896b1dde95a09f27a3ec7d027f995ec27cd358f",
+    "search_version": "0.90.5",
+    "search_checksum": "38b21f8b7d1cedd1fffe3ae928d3b06c6241ea1c",
 
     "etherpad_internal_hosts": [ "etherpad0", "etherpad1", "etherpad2" ],
     "etherpad_index": "%{nodesuffix}",

--- a/environments/qa/hiera/common.json
+++ b/environments/qa/hiera/common.json
@@ -76,8 +76,8 @@
     "search_index": "0",
     "search_data_dir": "/var/lib/elasticsearch",
     "search_memory_mb": 512,
-    "search_version": "0.20.6",
-    "search_checksum": "8896b1dde95a09f27a3ec7d027f995ec27cd358f",
+    "search_version": "0.90.5",
+    "search_checksum": "38b21f8b7d1cedd1fffe3ae928d3b06c6241ea1c",
 
     "etherpad_internal_hosts": [ "127.0.0.1" ],
     "etherpad_index": "%{nodesuffix}",

--- a/environments/staging/hiera/common.json
+++ b/environments/staging/hiera/common.json
@@ -95,8 +95,8 @@
     "search_data_dir": "/data/elasticsearch",
     "search_memory_mb": 2048,
     "search_newsize_mb": 784,
-    "search_version": "0.20.6",
-    "search_checksum": "8896b1dde95a09f27a3ec7d027f995ec27cd358f",
+    "search_version": "0.90.5",
+    "search_checksum": "38b21f8b7d1cedd1fffe3ae928d3b06c6241ea1c",
 
     "etherpad_internal_hosts": [ "etherpad0" ],
     "etherpad_index": "%{nodesuffix}",


### PR DESCRIPTION
- Verified unit tests locally
- Verified there are no configuration updates needed from 0.20.6 -> 0.90.5 by diffing the base 0.90.5

Installation steps:
1. Update puppet and apply the configuration on the search nodes. This will download the 0.90.5 package, but WILL NOT install the new version because elasticsearch is already installed
2. sudo apt-get remove elasticsearch on search0 and search1 using fabric. **This obviously will shut down the elasticsearch servers**
3. Apply puppet again. This will install the 0.90.5 versions and start up elasticsearch.

There will be a short search outage for this, but all index migration should happen automatically.
