### PR TITLE
Change redis installation strategy

### DIFF
--- a/environments/local/hiera/common.json
+++ b/environments/local/hiera/common.json
@@ -113,7 +113,11 @@
 
     "redis::owner": "redis",
     "redis::group": "redis",
-    "redis::version": "2:2.6.16-1~dotdeb.1",
+    "redis::version": "2.6.16-3",
+    "redis::checksums": {
+        "redis-tools": "5af52dcb3da1c4e2dd457521fb7e750d",
+        "redis-server": "e5dbeb3197630db3cf686d1c0925cd30"
+    },
 
     "hilary::config_activity_enabled": true,
     "hilary::config_previews_enabled": true,

--- a/environments/performance/hiera/common.json
+++ b/environments/performance/hiera/common.json
@@ -143,7 +143,11 @@
 
     "redis::owner": "redis",
     "redis::group": "redis",
-    "redis::version": "2:2.6.16-1~dotdeb.1",
+    "redis::version": "2.6.16-3",
+    "redis::checksums": {
+        "redis-tools": "5af52dcb3da1c4e2dd457521fb7e750d",
+        "redis-server": "e5dbeb3197630db3cf686d1c0925cd30"
+    },
 
     "rsyslog::clientOrServer": "client",
 

--- a/environments/production/hiera/common.json
+++ b/environments/production/hiera/common.json
@@ -148,7 +148,11 @@
 
     "redis::owner": "redis",
     "redis::group": "redis",
-    "redis::version": "2:2.6.16-1~dotdeb.1",
+    "redis::version": "2.6.16-3",
+    "redis::checksums": {
+        "redis-tools": "5af52dcb3da1c4e2dd457521fb7e750d",
+        "redis-server": "e5dbeb3197630db3cf686d1c0925cd30"
+    },
 
     "rsyslog::clientOrServer": "client",
     "rsyslog::server_logdir": "/var/log/rsyslog",

--- a/environments/qa/hiera/common.json
+++ b/environments/qa/hiera/common.json
@@ -127,7 +127,11 @@
 
     "redis::owner": "redis",
     "redis::group": "redis",
-    "redis::version": "2:2.6.16-1~dotdeb.1",
+    "redis::version": "2.6.16-3",
+    "redis::checksums": {
+        "redis-tools": "5af52dcb3da1c4e2dd457521fb7e750d",
+        "redis-server": "e5dbeb3197630db3cf686d1c0925cd30"
+    },
 
     "hilary::config_activity_enabled": true,
     "hilary::config_previews_enabled": true,

--- a/environments/staging/hiera/common.json
+++ b/environments/staging/hiera/common.json
@@ -145,7 +145,11 @@
 
     "redis::owner": "redis",
     "redis::group": "redis",
-    "redis::version": "2:2.6.16-1~dotdeb.1",
+    "redis::version": "2.6.16-3",
+    "redis::checksums": {
+        "redis-tools": "5af52dcb3da1c4e2dd457521fb7e750d",
+        "redis-server": "e5dbeb3197630db3cf686d1c0925cd30"
+    },
 
     "rsyslog::clientOrServer": "client",
     "rsyslog::server_logdir": "/var/log/rsyslog",


### PR DESCRIPTION
Redis appears to maintain packages here, dating back to 2010, though it doesn't seem it gets new versions very frequently -- I suspect about as frequently as the redis apt repository gets new versions.

To upgrade redis from the old deb (2.4.something in production right now I think), you'll want to:
1. Shutdown the slave
2. `redis-cli shutdown save`  <== will cause redis to persist its state and shut down
3. `sudo apt-get remove redis-server redis-tools libjemalloc1`
4. `puppet agent -t`
5. Startup redis
6. **Delete the dump.rdb file that was saved as a result of the `save`**
7. Restart HAProxy (to let the app start using the master again)
8. Perform steps 3-6 on the slave
9. Restart HAProxy (to let it acknowledge the save is up)

The `redis-cli shutdown save` technique can probably be used moving forward rather than the sync-to-slave-sync-back-to-master approach we've been taking in the past. Only downside is that restart takes longer with a large memory footprint, but realistically shouldn't be an issue at the moment.
