### PR TITLE
(ElasticSearch) Unbound bulk index queue_size

### DIFF
--- a/modules/elasticsearch/templates/elasticsearch.yml.erb
+++ b/modules/elasticsearch/templates/elasticsearch.yml.erb
@@ -380,3 +380,13 @@ monitor.jvm.gc.young.debug: 400ms
 monitor.jvm.gc.old.warn: 10s
 monitor.jvm.gc.old.info: 5s
 monitor.jvm.gc.old.debug: 2s
+
+################################## Thread Pools ################################
+
+# By default, the queue_size for bulk index pool is 50. In scenarios where OAE does a
+# re-indexall operation, it hammers the bulk indexing operations and exceeds 50, where
+# it begins dropping bulk requests and resulting in a partial re-index. Here, we unbound
+# it so that doesn't happen. This should be fine as bulk index requests are rare in regular
+# production scenarios
+threadpool.bulk.type: fixed
+threadpool.bulk.queue_size: -1


### PR DESCRIPTION
This resolves the issue with partial reindexes. It turns out, by default, if ES has more than 50 bulk index tasks in its handling queue at one time, it will start rejecting bulk index requests. This is how items were being dropped from indexing.

This change removes the limit altogether, as we don't do many bulk indexes during regular production runtime.
