### PR TITLE
Unattended-upgrades

### DIFF
--- a/modules/oaeservice/manifests/deps/common.pp
+++ b/modules/oaeservice/manifests/deps/common.pp
@@ -1,10 +1,37 @@
 class oaeservice::deps::common {
     include ::apt
+
     Class['::apt::update'] -> Package <| title != "python-software-properties" and title != "software-properties-common" |>
 
     package { 'build-essential': ensure => installed }
     package { 'automake': ensure => installed }
     package { 'libssl-dev': ensure => installed }
+    package { 'bsd-mailx': ensure => installed }
 
     include ::oaeservice::deps::package::git
+
+    # Automatically install security updates
+    class { '::apt::unattended_upgrades':
+        origins             => $::apt::params::origins,
+        blacklist           => [],
+
+        # Update, download and upgrade daily
+        update              => '1',
+        download            => '1',
+        upgrade             => '1',
+
+        # Clean apt's cache every week
+        autoclean           => '7',
+
+        # Do NOT reboot automatically
+        auto_reboot         => false,
+
+        # Do NOT install updates on shutdown
+        install_on_shutdown => false,
+
+        # Send an email if some of the updates could not be applied
+        # or if they require an email
+        mail_to             => "oae-monitoring@googlegroups.com",
+        mail_only_on_error  => true,
+    }
 }


### PR DESCRIPTION
Small patch that installed unattended upgrades. This will cause all the servers in the cluster to pull down and install unattended updates. It will _NOT_ reboot automatically so this is still something that we will have to do (if a reboot is required).

Roll-out guide:
1. Pull this into master and deploy to each server
2. On each server we will have to run `unattended-upgrades --debug` to get all the updates
   
   Now, because we haven't done this in a while a reboot will be required, so we should do each server (or each server within it's server group) sequentially and reboot them with slapchop. Rebooting with slapchop can be done by running `slapchop --directory qa --include <nodename> reboot` from the `oae-provisioning` repository.

Unattended upgrades will take further updates from there. If it fails to install an update or needs a reboot, it will send an email to oae-monitoring.
