### PR TITLE
Added a script to tail the Hilary logs on the syslog server

### DIFF
--- a/modules/rsyslog/manifests/init.pp
+++ b/modules/rsyslog/manifests/init.pp
@@ -28,7 +28,7 @@ class rsyslog (
             mode    => 0644
         }
 
-        file { "${server_logdir}/filter-bunyan":
+        file { "/usr/local/bin/filter-bunyan":
             content => template('rsyslog/filter-bunyan.erb'),
             owner   => 'root',
             group   => 'root',
@@ -36,8 +36,8 @@ class rsyslog (
             require => [ Package['rsyslog'], File[$server_logdir] ],
         }
 
-        file { "${server_logdir}/tail-hilary.sh":
-            content => template('rsyslog/tail-hilary.sh.erb'),
+        file { "/usr/local/bin/tail-hilary":
+            content => template('rsyslog/tail-hilary.erb'),
             owner   => 'root',
             group   => 'root',
             mode    => 0754,

--- a/modules/rsyslog/manifests/init.pp
+++ b/modules/rsyslog/manifests/init.pp
@@ -36,6 +36,14 @@ class rsyslog (
             require => [ Package['rsyslog'], File[$server_logdir] ],
         }
 
+        file { "${server_logdir}/tail-hilary.sh":
+            content => template('rsyslog/tail-hilary.sh.erb'),
+            owner   => 'root',
+            group   => 'root',
+            mode    => 0754,
+            require => [ Package['rsyslog'], File[$server_logdir] ],
+        }
+
         # Compress all log files that haven't been modified in over 1 day
         cron { 'compress-logs':
             ensure  => present,

--- a/modules/rsyslog/manifests/init.pp
+++ b/modules/rsyslog/manifests/init.pp
@@ -33,7 +33,6 @@ class rsyslog (
             owner   => 'root',
             group   => 'root',
             mode    => 0754,
-            require => [ Package['rsyslog'], File[$server_logdir] ],
         }
 
         file { "/usr/local/bin/tail-hilary":
@@ -41,7 +40,6 @@ class rsyslog (
             owner   => 'root',
             group   => 'root',
             mode    => 0754,
-            require => [ Package['rsyslog'], File[$server_logdir] ],
         }
 
         # Compress all log files that haven't been modified in over 1 day

--- a/modules/rsyslog/templates/filter-bunyan.erb
+++ b/modules/rsyslog/templates/filter-bunyan.erb
@@ -8,12 +8,22 @@
 # or:
 #
 # head -100 <path to log> | filter-bunyan
+#
+# Getting the errors out of a log:
+#
+# tail -f <path to log> | filter-bunyan -l error
 
-# * stdbuf 			- I think it defers flushing the buffer to stdout until a full line has been read. This seems to be necessary
+# * stdbuf 			            - I think it defers flushing the buffer to stdout until a full line has been read. This seems to be necessary
 # for both the tr and cut for tail -f to actually be formatted properly by bunyan.
 #
-# * tr -s ' ' 		- This "squeezes" spaces, as multiple spaces will trip up the parsing by "cut"
+# * tr -s ' ' 		            - This "squeezes" spaces, as multiple spaces will trip up the parsing by "cut"
 #
-# * cut -d' ' -f 6- - This takes columns 6 and on from a space-separated line. Basically slices out the syslog preamble
+# * cut -d' ' -f 6-             - This takes columns 6 and on from a space-separated line. Basically slices out the syslog preamble
+#
+# * bunyan $* -o bunyan         - Pipe the output to bunyan and pass the filters that were arguments to this script. The output will be standard json bunyan again
+#
+# * grep -v '^$'                - Because of stdbuf if bunyan filters a line we'd still end up with a blank line. Filter those out
+#
+# * bunyan                      - Pretty-print the remaining logs
 
-stdbuf -oL tr -s ' ' | stdbuf -oL cut -d' ' -f 6- | bunyan
+stdbuf -oL tr -s ' ' | stdbuf -oL cut -d' ' -f 6- | bunyan $* -o bunyan | grep -v '^$' | bunyan

--- a/modules/rsyslog/templates/tail-hilary.erb
+++ b/modules/rsyslog/templates/tail-hilary.erb
@@ -23,4 +23,4 @@ shift $((OPTIND-1))
 today_log="local0-$(date +%Y-%m-%d).log"
 
 # Tail and filter the logs
-tail -n $lines -f ${server_logdir}/app*/$today_log ${server_logdir}/pp*/$today_log ${server_logdir}/activity*/$today_log
+tail -n $lines -f <%= @server_logdir %>/app*/$today_log <%= @server_logdir %>/pp*/$today_log <%= @server_logdir %>/activity*/$today_log

--- a/modules/rsyslog/templates/tail-hilary.erb
+++ b/modules/rsyslog/templates/tail-hilary.erb
@@ -23,4 +23,4 @@ shift $((OPTIND-1))
 today_log="local0-$(date +%Y-%m-%d).log"
 
 # Tail and filter the logs
-tail -n $lines -f /var/log/rsyslog/app*/$today_log /var/log/rsyslog/pp*/$today_log /var/log/rsyslog/activity*/$today_log
+tail -n $lines -f ${server_logdir}/app*/$today_log ${server_logdir}/pp*/$today_log ${server_logdir}/activity*/$today_log

--- a/modules/rsyslog/templates/tail-hilary.erb
+++ b/modules/rsyslog/templates/tail-hilary.erb
@@ -3,7 +3,6 @@
 # Tail the logs outputted by all the Hilary application servers
 # Options:
 #   -n K    output the last K lines, instead of the last 10; or use -n +K to output lines starting with the Kth
-#   -l L    output lines of at least this level. Defaults to 30. For reference: 30=info, 40=warn, 50=error
 #
 
 # Reset in case getopts has been used previously in the shell
@@ -11,12 +10,9 @@ OPTIND=1
 
 # Get the arguments
 lines=10
-level=30
-while getopts "n:l:" opt; do
+while getopts "n:" opt; do
     case "$opt" in
     n)  lines=$OPTARG
-        ;;
-    l)  level=$OPTARG
         ;;
     esac
 done
@@ -26,13 +22,5 @@ shift $((OPTIND-1))
 # Hilary logs to local0-2015-03-26.log
 today_log="local0-$(date +%Y-%m-%d).log"
 
-# Generate a shitty regex that we can use to grep out log lines of a certain level
-regex='level":'$level
-level=$(($level + 10))
-while [ $level -lt 51 ] ; do
-    regex=$regex'\|level":'$level
-    level=$(($level + 10))
-done
-
 # Tail and filter the logs
-tail -n $lines -f app*/$today_log pp*/$today_log activity*/$today_log | grep $regex
+tail -n $lines -f /var/log/rsyslog/app*/$today_log /var/log/rsyslog/pp*/$today_log /var/log/rsyslog/activity*/$today_log

--- a/modules/rsyslog/templates/tail-hilary.sh.erb
+++ b/modules/rsyslog/templates/tail-hilary.sh.erb
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# Tail the logs outputted by all the Hilary application servers
+# Options:
+#   -n K    output the last K lines, instead of the last 10; or use -n +K to output lines starting with the Kth
+#   -l L    output lines of at least this level. Defaults to 30. For reference: 30=info, 40=warn, 50=error
+#
+
+# Reset in case getopts has been used previously in the shell
+OPTIND=1
+
+# Get the arguments
+lines=10
+level=30
+while getopts "n:l:" opt; do
+    case "$opt" in
+    n)  lines=$OPTARG
+        ;;
+    l)  level=$OPTARG
+        ;;
+    esac
+done
+
+shift $((OPTIND-1))
+
+# Hilary logs to local0-2015-03-26.log
+today_log="local0-$(date +%Y-%m-%d).log"
+
+# Generate a shitty regex that we can use to grep out log lines of a certain level
+regex='level":'$level
+level=$(($level + 10))
+while [ $level -lt 51 ] ; do
+    regex=$regex'\|level":'$level
+    level=$(($level + 10))
+done
+
+# Tail and filter the logs
+tail -n $lines -f app*/$today_log pp*/$today_log activity*/$today_log | grep $regex


### PR DESCRIPTION
This should create a bash script at `/var/log/rsyslog/tail-hilary.sh`.

I got tired of typing out `tail -f app*/loca....` and decided to write a small script. You can specify the number of lines that should be outputted and grep the log level. You can also pipe it through the `filter-bunyan` script to get pretty output.

For example:

```
root@syslog@production:/var/log/rsyslog# ./tail-hilary.sh -n 500 -l 40 | ./filter-bunyan 
[2015-03-27T01:44:43.541Z]  WARN: oae-activity-push/1041 on app0: Socket was not authenticated within an acceptable duration (sid=e188d701-fb1a-42ec-b505-63afe9186a40, durationInMs=5000)
[2015-03-27T04:04:06.817Z]  WARN: oae-activity-push/1041 on app0: Socket was not authenticated within an acceptable duration (sid=01b7973b-34a2-4a98-a9d2-6f71eb36ee0d, durationInMs=5000)
[2015-03-27T04:11:00.809Z]  WARN: oae-activity-push/1041 on app0: Socket was not authenticated within an acceptable duration (sid=f3f0b333-f4c1-4628-8b0c-4ea677140a0d, durationInMs=5000)
[2015-03-27T04:15:12.598Z]  WARN: oae-activity-push/1041 on app0: Socket was not authenticated within an acceptable duration (sid=a1c0d77d-473b-4c9b-ae08-775b03196529, durationInMs=5000)
[2015-03-27T04:15:13.267Z]  WARN: oae-activity-push/1041 on app0: Socket was not authenticated within an acceptable duration (sid=20f7053d-8ad6-4610-a705-4448aaf0b6f6, durationInMs=5000)
[2015-03-27T04:16:27.213Z]  WARN: oae-activity-push/1041 on app0: Socket was not authenticated within an acceptable duration (sid=689061c5-808f-41f0-9011-24c34ec8e675, durationInMs=5000)
[2015-03-27T04:37:57.263Z]  WARN: oae-server/1041 on app0: CSRF validation failed: attempted to execute unsafe operation from untrusted origin (method=POST, host=thefold.oaeproject.org, targetPath=/api/auth/cas/callback)
[2015-03-27T08:37:37.203Z]  WARN: oae-activity-push/1041 on app0: Socket was not authenticated within an acceptable duration (sid=98c4dee3-0ee6-48a9-a42a-e2eabb926bed, durationInMs=5000)
[2015-03-27T04:11:01.158Z]  WARN: oae-activity-push/17881 on app1: Socket was not authenticated within an acceptable duration (sid=ea7ae565-7976-46f3-abf5-5e5592656e86, durationInMs=5000)
[2015-03-27T04:16:27.520Z]  WARN: oae-activity-push/17881 on app1: Socket was not authenticated within an acceptable duration (sid=fa332e59-ba8a-4f18-ab0f-358c703dc9ee, durationInMs=5000)
[2015-03-27T07:24:32.101Z]  WARN: oae-server/17881 on app1: CSRF validation failed: attempted to execute unsafe operation from untrusted origin (method=POST, host=thefold.oaeproject.org, targetPath=/api/auth/cas/callback)
[2015-03-27T08:37:37.167Z]  WARN: oae-activity-push/17881 on app1: Socket was not authenticated within an acceptable duration (sid=eb86ba3b-f4f6-4e01-afd6-f46e951408e8, durationInMs=5000)
```