### PR TITLE
removed OpsCenter from backups

### DIFF
--- a/environments/production/hiera/db.json
+++ b/environments/production/hiera/db.json
@@ -7,7 +7,7 @@
         "::oaeservice::backup::cassandra"
     ],
 
-    "duplicity::params::excludes": ["**/snapshots"],
+    "duplicity::params::excludes": ["**/snapshots","**/OpsCenter"],
     "duplicity::params::pubkey_id": "471DE501",
     "duplicity::params::bucket": "oae-cassandra-backup",
     "duplicity::params::hour": 4,

--- a/environments/production/hiera/db.json
+++ b/environments/production/hiera/db.json
@@ -7,7 +7,7 @@
         "::oaeservice::backup::cassandra"
     ],
 
-    "duplicity::params::excludes": ["**/snapshots","**/OpsCenter"],
+    "duplicity::params::excludes": ["**/snapshots","OpsCenter"],
     "duplicity::params::pubkey_id": "471DE501",
     "duplicity::params::bucket": "oae-cassandra-backup",
     "duplicity::params::hour": 4,


### PR DESCRIPTION
It'll take a little while for the current backup cycle to clear before OpsCenter is removed completely.