### PR TITLE
Clean puppet reports

### DIFF
--- a/modules/oaeservice/manifests/puppet.pp
+++ b/modules/oaeservice/manifests/puppet.pp
@@ -12,7 +12,7 @@ class oaeservice::puppet {
   # the report dir is not in puppet-hilary anywhere so extracted direct from puppet.conf
   cron { 'clean-puppet-reports':
     ensure  => present,
-    command => "find $(awk -F= '/^reportdir/ { print $2 }' /etc/puppet/puppet.conf) -type f -iname \*.yaml -ctime +7 -delete",
+    command => "find $(awk -F= '/^reportdir/ { print $2 }' /etc/puppet/puppet.conf) -type f -iname \*.yaml -ctime +30 -delete",
     user    => 'root',
     hour    => '3',
     weekday => 'Sunday',

--- a/modules/oaeservice/manifests/puppet.pp
+++ b/modules/oaeservice/manifests/puppet.pp
@@ -7,4 +7,15 @@ class oaeservice::puppet {
   class { 'puppetdb::master::config':
     puppetdb_server => 'puppet',
   }
+
+  # clean puppet report logs
+  # the report dir is not in puppet-hilary anywhere so extracted direct from puppet.conf
+  cron { 'clean-puppet-reports':
+    ensure  => present,
+    command => "find $(awk -F= '/^reportdir/ { print $2 }' /etc/puppet/puppet.conf) -type f -iname \*.yaml -ctime +7 -delete",
+    user    => 'root',
+    hour    => '3',
+    weekday => 'Sunday',
+  }
 }
+


### PR DESCRIPTION
We're keeping puppet run logs for ever and they use space and we don't need them so this sets a cronjob to remove puppet reports older than 30 days.
