### PR TITLE
put **/ back into duplicity's OpsCenter exclude

### DIFF
--- a/environments/production/hiera/db.json
+++ b/environments/production/hiera/db.json
@@ -7,7 +7,7 @@
         "::oaeservice::backup::cassandra"
     ],
 
-    "duplicity::params::excludes": ["**/snapshots","OpsCenter"],
+    "duplicity::params::excludes": ["**/snapshots","**/OpsCenter"],
     "duplicity::params::pubkey_id": "471DE501",
     "duplicity::params::bucket": "oae-cassandra-backup",
     "duplicity::params::hour": 4,


### PR DESCRIPTION
When I examined the error message from last night's failure it indicated that the OpsCenter exclude should be **/OpsCenter. I have changed appropriately, hopefully that should resolve the issue.
