### PR TITLE
Warnings for short fingerprints

### DIFF
--- a/modules/oaeservice/manifests/deps/apt/nginx.pp
+++ b/modules/oaeservice/manifests/deps/apt/nginx.pp
@@ -2,6 +2,6 @@ class oaeservice::deps::apt::nginx {
     ::apt::source { 'nginx':
         location    => 'http://nginx.org/packages/ubuntu/',
         repos       => 'nginx',
-        key         => 'ABF5BD827BD9BF62',
+        key         => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62',
     }
 }

--- a/modules/oaeservice/manifests/deps/apt/switch.pp
+++ b/modules/oaeservice/manifests/deps/apt/switch.pp
@@ -1,13 +1,13 @@
 class oaeservice::deps::apt::switch {
     ::apt::key { 'switch.ch':
-        key         => '15B76742',
+        key         => '294E37D154156E00FB96D7AA26C3C46915B76742',
         key_source  => 'http://pkg.switch.ch/switchaai/SWITCHaai-swdistrib.asc',
     }
     ::apt::source { 'switch.ch':
         location    => 'http://pkg.switch.ch/switchaai/ubuntu',
         release     => 'precise',
         repos       => 'main',
-        key         => '15B76742',
+        key         => '294E37D154156E00FB96D7AA26C3C46915B76742',
 
         # Switch doesn't publish their sources into the apt repository, don't
         # include them or you will get errors when trying to run `apt-get update`

--- a/modules/oaeservice/manifests/deps/ppa/gm.pp
+++ b/modules/oaeservice/manifests/deps/ppa/gm.pp
@@ -1,5 +1,5 @@
 class oaeservice::deps::ppa::gm {
     include apt
-    apt::key { 'pteichman': key => '6159DD90' }
+    apt::key { 'pteichman': key => '95BFBE33C2B9D4E0978A1C19555CD5CC6159DD90' }
     apt::ppa { 'ppa:pteichman/graphicsmagick': }
 }

--- a/modules/oaeservice/manifests/deps/ppa/nodejs.pp
+++ b/modules/oaeservice/manifests/deps/ppa/nodejs.pp
@@ -1,6 +1,6 @@
 class oaeservice::deps::ppa::nodejs {
     include apt
-    apt::key { 'chris-lea': key => '4BD6EC30' }
+    apt::key { 'chris-lea': key => '47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30' }
     apt::ppa { 'ppa:chris-lea/node.js': }
     apt::ppa { 'ppa:chris-lea/node.js-legacy': }
 }

--- a/modules/oaeservice/manifests/deps/ppa/oae.pp
+++ b/modules/oaeservice/manifests/deps/ppa/oae.pp
@@ -1,6 +1,6 @@
 class oaeservice::deps::ppa::oae {
     include apt
-    apt::key { 'stuart-freeman': key => '52340974' }
-    apt::key { 'branden-visser': key => 'B77CA805' }
+    apt::key { 'stuart-freeman': key => '13C0BEBC9A6BDCA6E8A1BA94EF88D79652340974' }
+    apt::key { 'branden-visser': key => 'D410B2242BFBEFB8CD0D0112120D71BAB77CA805' }
     apt::ppa { 'ppa:oae/deps': }
 }


### PR DESCRIPTION
puppet is throwing warnings like:

    Warning: /Apt_key[stuart-freeman]: The id should be a full fingerprint (40 characters), see README.
    Warning: /Apt_key[branden-visser]: The id should be a full fingerprint (40 characters), see README.
    Warning: /Apt_key[Add key: ABF5BD827BD9BF62 from Apt::Source nginx]: The id should be a full fingerprint (40 characters), see README.

These should be relatively easy to fix by putting in the 40 char fingerprints.