### PR TITLE
Move mixpanel enable boolean to common.json

### DIFF
--- a/environments/local/hiera/common.json
+++ b/environments/local/hiera/common.json
@@ -132,5 +132,6 @@
     "oaeservice::limits::user_hard_max_files": "32000",
 
     "cassandra::initial_token": 0,
-    "cassandra::listen_address": "127.0.0.1"
+    "cassandra::listen_address": "127.0.0.1",
+    "mixpanel_enabled": false
 }

--- a/environments/performance/hiera/common.json
+++ b/environments/performance/hiera/common.json
@@ -169,5 +169,6 @@
     "rabbitmq::server::wipe_db_on_cookie_change": true,
 
     "oaeservice::limits::user_soft_max_files": "16000",
-    "oaeservice::limits::user_hard_max_files": "32000"
+    "oaeservice::limits::user_hard_max_files": "32000",
+    "mixpanel_enabled": false
 }

--- a/environments/production/hiera/common.json
+++ b/environments/production/hiera/common.json
@@ -176,5 +176,6 @@
     "rabbitmq::server::wipe_db_on_cookie_change": true,
 
     "oaeservice::limits::user_soft_max_files": "16000",
-    "oaeservice::limits::user_hard_max_files": "32000"
+    "oaeservice::limits::user_hard_max_files": "32000",
+    "mixpanel_enabled": true
 }

--- a/environments/qa/hiera/common.json
+++ b/environments/qa/hiera/common.json
@@ -154,5 +154,6 @@
     "automation_youtube_api_key": "unset",
 
     "oaeservice::limits::user_soft_max_files": "8192",
-    "oaeservice::limits::user_hard_max_files": "32000"
+    "oaeservice::limits::user_hard_max_files": "32000",
+    "mixpanel_enabled": false
 }

--- a/environments/staging/hiera/common.json
+++ b/environments/staging/hiera/common.json
@@ -171,6 +171,6 @@
     "rabbitmq::server::wipe_db_on_cookie_change": true,
 
     "oaeservice::limits::user_soft_max_files": "16000",
-    "oaeservice::limits::user_hard_max_files": "32000"
-
+    "oaeservice::limits::user_hard_max_files": "32000",
+    "mixpanel_enabled": false
 }


### PR DESCRIPTION
It's currently in the secure.json which isn't tracked by git to protect passwords, so when it is copied from environment to environment mixpanel can end up enabled where it shouldn't be.