### PR TITLE
updated shibboleth to 2.5.5-0

### DIFF
--- a/modules/shibboleth/manifests/sp.pp
+++ b/modules/shibboleth/manifests/sp.pp
@@ -14,7 +14,7 @@ class shibboleth::sp (
 
     # Ensure that the required shibboleth packages have been installed
     package { 'shibboleth':
-        ensure  => '2.5.3-0switchaai1',
+        ensure  => '2.5.5-0switchaai1',
     }
 
     # Configure the shibboleth SP config


### PR DESCRIPTION
I have tested shib 2.5.5 on qa1, seems to work correctly using a protectnetwork login, which uses the UK federation. The upgrade only required the shibboleth package itself to be updated.
Other than just testing it works I've checked the logs for different errors and checked metadata of the browser communication and it looks great.
I think we can upgrade shib in production to 2.5.5.
